### PR TITLE
Moving skydoc out of the public folder.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,13 +74,13 @@ directory.
 To rebuild the documentation run:
 
 ```
-bazel build platformio:platformio_docs
+bazel build docs:platformio_docs
 ```
 
 And then copy the created markdown file:
 
 ```
-cp $(bazel info bazel-bin)/platformio/platformio_doc.md docs/
+cp $(bazel info bazel-bin)/docs/platformio_doc.md docs/
 ```
 
 ## Examples

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -1,0 +1,7 @@
+load("@io_bazel_skydoc//stardoc:stardoc.bzl", "stardoc")
+
+stardoc(
+    name = "platformio_docs",
+    input = "//platformio:platformio.bzl",
+    out = "platformio_doc.md",
+)

--- a/platformio/BUILD
+++ b/platformio/BUILD
@@ -7,10 +7,4 @@ filegroup(
     srcs = ["platformio.ini.tmpl"],
 )
 
-load("@io_bazel_skydoc//stardoc:stardoc.bzl", "stardoc")
-
-stardoc(
-    name = "platformio_docs",
-    input = "platformio.bzl",
-    out = "platformio_doc.md",
-)
+exports_files(["platformio.bzl"])


### PR DESCRIPTION
So external dependencies don't need to know what it is.