### PR TITLE
Adjusting expected firmware location.

### DIFF
--- a/platformio/platformio.bzl
+++ b/platformio/platformio.bzl
@@ -339,7 +339,7 @@ platformio_project = rule(
     outputs = {
       "main_cpp": "src/main.cpp",
       "platformio_ini": "platformio.ini",
-      "firmware_elf": ".pioenvs/%{board}/firmware.elf",
+      "firmware_elf": ".pio/build/%{board}/firmware.elf",
     },
     attrs={
       "_platformio_ini_tmpl": attr.label(


### PR DESCRIPTION
Adjusted according to documentation of Platformio4:

https://docs.platformio.org/en/latest/projectconf/section_platformio.html#build-dir

Fixes #14.