### PR TITLE
Add a way to extend the build flags

### DIFF
--- a/docs/platformio_doc.md
+++ b/docs/platformio_doc.md
@@ -1,4 +1,7 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
 <a name="#platformio_library"></a>
+
 ## platformio_library
 
 <pre>
@@ -116,10 +119,11 @@ expected by PlatformIO.
 
 
 <a name="#platformio_project"></a>
+
 ## platformio_project
 
 <pre>
-platformio_project(<a href="#platformio_project-name">name</a>, <a href="#platformio_project-board">board</a>, <a href="#platformio_project-deps">deps</a>, <a href="#platformio_project-environment_kwargs">environment_kwargs</a>, <a href="#platformio_project-framework">framework</a>, <a href="#platformio_project-platform">platform</a>, <a href="#platformio_project-src">src</a>)
+platformio_project(<a href="#platformio_project-name">name</a>, <a href="#platformio_project-board">board</a>, <a href="#platformio_project-build_flags">build_flags</a>, <a href="#platformio_project-deps">deps</a>, <a href="#platformio_project-environment_kwargs">environment_kwargs</a>, <a href="#platformio_project-framework">framework</a>, <a href="#platformio_project-platform">platform</a>, <a href="#platformio_project-src">src</a>)
 </pre>
 
 
@@ -170,6 +174,19 @@ uploading.
 find the supported boards in the
 [PlatformIO Embedded Boards Explorer](http://platformio.org/boards). This is
 mandatory.
+        </p>
+      </td>
+    </tr>
+    <tr id="platformio_project-build_flags">
+      <td><code>build_flags</code></td>
+      <td>
+        List of strings; optional
+        <p>
+          A list of strings, any provided strings will directly appear in the
+generated platformio.ini file in the build_flags option for the selected
+env:board section. Refer to the [Project Configuration File manual](
+http://docs.platformio.org/en/latest/projectconf.html) for the available
+options.
         </p>
       </td>
     </tr>
@@ -227,204 +244,6 @@ this project.
         <p>
           A string, the name of the C++ source file, the main file for 
 the project that contains the Arduino setup() and loop() functions. This is mandatory.
-        </p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
-
-## _emit_build_action
-
-<pre>
-_emit_build_action(<a href="#_emit_build_action-ctx">ctx</a>, <a href="#_emit_build_action-project_dir">project_dir</a>)
-</pre>
-
-Emits a Bazel action that unzips the libraries and builds the project.
-
-### Parameters
-
-<table class="params-table">
-  <colgroup>
-    <col class="col-param" />
-    <col class="col-description" />
-  </colgroup>
-  <tbody>
-    <tr id="_emit_build_action-ctx>
-      <td><code>ctx</code></td>
-      <td>
-        required.
-        <p>
-          The Skylark context.
-        </p>
-      </td>
-    </tr>
-    <tr id="_emit_build_action-project_dir>
-      <td><code>project_dir</code></td>
-      <td>
-        required.
-        <p>
-          A string, the main directory of the PlatformIO project.
-  This is where the zip files will be extracted.
-        </p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
-
-## _emit_executable_action
-
-<pre>
-_emit_executable_action(<a href="#_emit_executable_action-ctx">ctx</a>)
-</pre>
-
-Emits a Bazel action that produces executable script.
-
-When the script is executed, the compiled firmware gets uploaded to the
-Arduino device.
-
-
-### Parameters
-
-<table class="params-table">
-  <colgroup>
-    <col class="col-param" />
-    <col class="col-description" />
-  </colgroup>
-  <tbody>
-    <tr id="_emit_executable_action-ctx>
-      <td><code>ctx</code></td>
-      <td>
-        required.
-        <p>
-          The Skylark context.
-        </p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
-
-## _emit_ini_file_action
-
-<pre>
-_emit_ini_file_action(<a href="#_emit_ini_file_action-ctx">ctx</a>)
-</pre>
-
-Emits a Bazel action that generates the PlatformIO configuration file.
-
-### Parameters
-
-<table class="params-table">
-  <colgroup>
-    <col class="col-param" />
-    <col class="col-description" />
-  </colgroup>
-  <tbody>
-    <tr id="_emit_ini_file_action-ctx>
-      <td><code>ctx</code></td>
-      <td>
-        required.
-        <p>
-          The Skylark context.
-        </p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
-
-## _emit_main_file_action
-
-<pre>
-_emit_main_file_action(<a href="#_emit_main_file_action-ctx">ctx</a>)
-</pre>
-
-Emits a Bazel action that outputs the project main C++ file.
-
-### Parameters
-
-<table class="params-table">
-  <colgroup>
-    <col class="col-param" />
-    <col class="col-description" />
-  </colgroup>
-  <tbody>
-    <tr id="_emit_main_file_action-ctx>
-      <td><code>ctx</code></td>
-      <td>
-        required.
-        <p>
-          The Skylark context.
-        </p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
-
-## _platformio_library_impl
-
-<pre>
-_platformio_library_impl(<a href="#_platformio_library_impl-ctx">ctx</a>)
-</pre>
-
-Collects all transitive dependencies and emits the zip output.
-
-Outputs a zip file containing the library in the directory structure expected
-by PlatformIO.
-
-
-### Parameters
-
-<table class="params-table">
-  <colgroup>
-    <col class="col-param" />
-    <col class="col-description" />
-  </colgroup>
-  <tbody>
-    <tr id="_platformio_library_impl-ctx>
-      <td><code>ctx</code></td>
-      <td>
-        required.
-        <p>
-          The Skylark context.
-        </p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
-
-## _platformio_project_impl
-
-<pre>
-_platformio_project_impl(<a href="#_platformio_project_impl-ctx">ctx</a>)
-</pre>
-
-Builds and optionally uploads (when executed) a PlatformIO project.
-
-Outputs the C++ source file containing the Arduino setup() and loop()
-functions renamed according to PlatformIO needs, a platformio_ini with the
-project configuration file for PlatformIO and the firmware. The firmware_elf
-is the compiled version of the Arduino firmware for the specified board.
-
-
-### Parameters
-
-<table class="params-table">
-  <colgroup>
-    <col class="col-param" />
-    <col class="col-description" />
-  </colgroup>
-  <tbody>
-    <tr id="_platformio_project_impl-ctx>
-      <td><code>ctx</code></td>
-      <td>
-        required.
-        <p>
-          The Skylark context.
         </p>
       </td>
     </tr>

--- a/platformio/platformio.bzl
+++ b/platformio/platformio.bzl
@@ -145,6 +145,12 @@ def _emit_ini_file_action(ctx):
     if key == "" or value == "":
       continue
     environment_kwargs.append("{key} = {value}".format(key=key, value=value))
+
+  build_flags = []
+  for flag in ctx.attr.build_flags:
+      if flag == "":
+          continue
+      build_flags.append(flag)
   ctx.actions.expand_template(
       template=ctx.file._platformio_ini_tmpl,
       output=ctx.outputs.platformio_ini,
@@ -153,6 +159,7 @@ def _emit_ini_file_action(ctx):
           "%platform%": ctx.attr.platform,
           "%framework%": ctx.attr.framework,
           "%environment_kwargs%": "\n".join(environment_kwargs),
+          "%build_flags%": " ".join(build_flags),
       },
   )
 
@@ -386,6 +393,16 @@ this project.
         doc = """
 A dictionary of strings to strings, any provided keys and
 values will directly appear in the generated platformio.ini file under the
+env:board section. Refer to the [Project Configuration File manual](
+http://docs.platformio.org/en/latest/projectconf.html) for the available
+options.
+""",
+      ),
+      "build_flags": attr.string_list(
+        allow_empty = True,
+        doc = """
+A list of strings, any provided strings will directly appear in the
+generated platformio.ini file in the build_flags option for the selected
 env:board section. Refer to the [Project Configuration File manual](
 http://docs.platformio.org/en/latest/projectconf.html) for the available
 options.

--- a/platformio/platformio.ini.tmpl
+++ b/platformio/platformio.ini.tmpl
@@ -5,7 +5,7 @@
 env_default = %board%
 
 [env:%board%]
-build_flags = -Wall -DPLATFORMIO_BUILD
+build_flags = -Wall -DPLATFORMIO_BUILD %build_flags%
 lib_ldf_mode = deep+
 platform = %platform%
 board = %board%


### PR DESCRIPTION
Fixes #16 

I'm not exactly sure why there's a pretty big chunk of the doc that gets removed, I regenerated it with `bazel build //docs:platformio_docs` and took the resulting file from `bazel-bin/docs/platformio_doc.md`...