### PR TITLE
Fixed Platformios Click crashing within Bazel

### DIFF
--- a/platformio/platformio.bzl
+++ b/platformio/platformio.bzl
@@ -210,6 +210,9 @@ def _emit_build_action(ctx, project_dir):
       env={
         # The PlatformIO binary assumes that the build tools are in the path.
         "PATH":"/bin:/usr/bin:/usr/local/bin:/usr/sbin:/sbin",
+        "LC_ALL":"C.UTF-8",
+        "LANG":"C.UTF-8",
+ 
       },
       execution_requirements={
         # PlatformIO cannot be executed in a sandbox.

--- a/platformio/platformio.bzl
+++ b/platformio/platformio.bzl
@@ -210,9 +210,11 @@ def _emit_build_action(ctx, project_dir):
       env={
         # The PlatformIO binary assumes that the build tools are in the path.
         "PATH":"/bin:/usr/bin:/usr/local/bin:/usr/sbin:/sbin",
+
+        # Changes the Encoding to allow PlatformIO's Click to work as expected
+        # See https://github.com/mum4k/platformio_rules/issues/22 
         "LC_ALL":"C.UTF-8",
         "LANG":"C.UTF-8",
- 
       },
       execution_requirements={
         # PlatformIO cannot be executed in a sandbox.


### PR DESCRIPTION
Fixes bug as described in #22.

Not sure how widespread this bug is for users, but I need this fix in order to use the extension.