### PR TITLE
Remind user to load git_repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ where they are needed.
 See [Releases](https://github.com/mum4k/platformio_rules/releases) for the most up to date version to substitute for `tag`.
 
 ```
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
 git_repository(
     name = "platformio_rules",
     remote = "http://github.com/mum4k/platformio_rules.git",


### PR DESCRIPTION
Amend the setup instructions to include a load directive for git_repository. This seems to be idiomatic for bazel rules packages (ex: https://github.com/bazelbuild/rules_docker)