### PR TITLE
Update dependencies and replace the old name Skylark to Starlark

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.com/mum4k/platformio_rules.svg?branch=master)](https://travis-ci.com/mum4k/platformio_rules)
 
-These are Bazel Skylark rules for building and uploading
+These are Bazel Starlark rules for building and uploading
 [Arduino](https://www.arduino.cc/) programs using the
 [PlatformIO](http://platformio.org/) build system.
 
@@ -50,7 +50,7 @@ git_repository(
 
 ### Load the rule definitions in the BUILD file
 
-To load the Skylark definitions in your BUILD file add the following at the top
+To load the Starlark definitions in your BUILD file add the following at the top
 of the BUILD file.
 
 ```
@@ -72,7 +72,7 @@ See the [generated documentation](docs/platformio_doc.md).
 
 ## Rules documentation
 
-These rules have standard Skylark documentation inside the platformio_docs
+These rules have standard Starlark documentation inside the platformio_docs
 directory.
 
 To rebuild the documentation run:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,55 +2,32 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(
     name = "com_google_googletest",
-    urls = ["https://github.com/google/googletest/archive/release-1.8.1.zip"],
-    strip_prefix = "googletest-release-1.8.1",
-    sha256 = "927827c183d01734cc5cfef85e0ff3f5a92ffe6188e0d18e909c5efebf28a0c7",
+    urls = ["https://github.com/google/googletest/archive/release-1.12.1.zip"],
+    strip_prefix = "googletest-release-1.12.1",
+    sha256 = "24564e3b712d3eb30ac9a85d92f7d720f60cc0173730ac166f27dda7fed76cb2",
 )
 
-# Skydoc, documentation generator for custom Bazel rules.
+# Stardoc, documentation generator for custom Bazel rules.
 http_archive(
     name = "io_bazel_rules_sass",
-    url = "https://github.com/bazelbuild/rules_sass/archive/1.17.2.zip",
-    strip_prefix = "rules_sass-1.17.2",
-    sha256 = "e5316ee8a09d1cbb732d3938b400836bf94dba91a27476e9e27706c4c0edae1f",
+    url = "https://github.com/bazelbuild/rules_sass/archive/1.57.0.zip",
+    strip_prefix = "rules_sass-1.57.0",
+    sha256 = "05db38271919d3d209a9f58db412a5bf2af2def7d4c1fae17b401dccbad97178",
 )
-
-# Fetch required transitive dependencies. This is an optional step because you
-# can always fetch the required NodeJS transitive dependency on your own.
-load("@io_bazel_rules_sass//:package.bzl", "rules_sass_dependencies")
-rules_sass_dependencies()
-
-# Setup repositories which are needed for the Sass rules.
-load("@io_bazel_rules_sass//:defs.bzl", "sass_repositories")
-sass_repositories()
-
-# Setup the NodeJS toolchain
-load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories")
-node_repositories()
 
 http_archive(
     name = "io_bazel_skylib",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/archive/0.7.0.zip"],
-    sha256 = "bce240a0749dfc52fab20dce400b4d5cf7c28b239d64f8fd1762b3c9470121d8",
+    urls = ["https://github.com/bazelbuild/bazel-skylib/archive/1.3.0.zip"],
+    sha256 = "4756ab3ec46d94d99e5ed685d2d24aece484015e45af303eb3a11cab3cdc2e71",
 )
-
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 git_repository(
-    name = "io_bazel_skydoc",
-    remote = "https://github.com/bazelbuild/skydoc.git",
-    tag = "0.3.0",
+    name = "io_bazel_stardoc",
+    remote = "https://github.com/bazelbuild/stardoc.git",
+    tag = "0.5.3",
 )
 
-load("@io_bazel_skydoc//:setup.bzl", "skydoc_repositories")
-skydoc_repositories()
-
-load("@io_bazel_rules_sass//:package.bzl", "rules_sass_dependencies")
-rules_sass_dependencies()
-
-load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories")
-node_repositories()
-
-load("@io_bazel_rules_sass//:defs.bzl", "sass_repositories")
-sass_repositories()
+load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
+stardoc_repositories()

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_skydoc//stardoc:stardoc.bzl", "stardoc")
+load("@io_bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
 
 stardoc(
     name = "platformio_docs",

--- a/docs/platformio_doc.md
+++ b/docs/platformio_doc.md
@@ -1,6 +1,13 @@
 <!-- Generated with Stardoc: http://skydoc.bazel.build -->
 
-<a name="#platformio_library"></a>
+PlatformIO Rules.
+
+These are Bazel Starlark rules for building and uploading
+[Arduino](https://www.arduino.cc/) programs using the
+[PlatformIO](http://platformio.org/) build system.
+
+
+<a id="platformio_library"></a>
 
 ## platformio_library
 
@@ -42,7 +49,7 @@ will be set when the library is built by the PlatformIO build system.
 
 ```
 #ifdef PLATFORMIO_BUILD
-#include <My_lib.h>  // This is how PlatformIO sees and includes the library.
+#include &lt;My_lib.h&gt;  // This is how PlatformIO sees and includes the library.
 #else
 #include "actual/path/to/my_lib.h" // This is for native C++.
 #endif
@@ -52,73 +59,20 @@ Outputs a single zip file containing the C++ library in the directory structure
 expected by PlatformIO.
 
 
-### Attributes
-
-<table class="params-table">
-  <colgroup>
-    <col class="col-param" />
-    <col class="col-description" />
-  </colgroup>
-  <tbody>
-    <tr id="platformio_library-name">
-      <td><code>name</code></td>
-      <td>
-        <a href="https://bazel.build/docs/build-ref.html#name">Name</a>; required
-        <p>
-          A unique name for this target.
-        </p>
-      </td>
-    </tr>
-    <tr id="platformio_library-add_hdrs">
-      <td><code>add_hdrs</code></td>
-      <td>
-        <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a>; optional
-        <p>
-          A list of labels, additional header files to include in the resulting zip file.
-        </p>
-      </td>
-    </tr>
-    <tr id="platformio_library-add_srcs">
-      <td><code>add_srcs</code></td>
-      <td>
-        <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a>; optional
-        <p>
-          A list of labels, additional source files to include in the resulting zip file.
-        </p>
-      </td>
-    </tr>
-    <tr id="platformio_library-deps">
-      <td><code>deps</code></td>
-      <td>
-        <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a>; optional
-        <p>
-          A list of Bazel targets, other platformio_library targets that this one depends on.
-        </p>
-      </td>
-    </tr>
-    <tr id="platformio_library-hdr">
-      <td><code>hdr</code></td>
-      <td>
-        <a href="https://bazel.build/docs/build-ref.html#labels">Label</a>; required
-        <p>
-          A string, the name of the C++ header file. This is mandatory.
-        </p>
-      </td>
-    </tr>
-    <tr id="platformio_library-src">
-      <td><code>src</code></td>
-      <td>
-        <a href="https://bazel.build/docs/build-ref.html#labels">Label</a>; optional
-        <p>
-          A string, the name of the C++ source file. This is optional.
-        </p>
-      </td>
-    </tr>
-  </tbody>
-</table>
+**ATTRIBUTES**
 
 
-<a name="#platformio_project"></a>
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="platformio_library-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="platformio_library-add_hdrs"></a>add_hdrs |  A list of labels, additional header files to include in the resulting zip file.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
+| <a id="platformio_library-add_srcs"></a>add_srcs |  A list of labels, additional source files to include in the resulting zip file.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
+| <a id="platformio_library-deps"></a>deps |  A list of Bazel targets, other platformio_library targets that this one depends on.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
+| <a id="platformio_library-hdr"></a>hdr |  A string, the name of the C++ header file. This is mandatory.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="platformio_library-src"></a>src |  A string, the name of the C++ source file. This is optional.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
+
+
+<a id="platformio_project"></a>
 
 ## platformio_project
 
@@ -148,106 +102,18 @@ the firmware_hex is the firmware in the hexadecimal format ready for
 uploading.
 
 
-### Attributes
+**ATTRIBUTES**
 
-<table class="params-table">
-  <colgroup>
-    <col class="col-param" />
-    <col class="col-description" />
-  </colgroup>
-  <tbody>
-    <tr id="platformio_project-name">
-      <td><code>name</code></td>
-      <td>
-        <a href="https://bazel.build/docs/build-ref.html#name">Name</a>; required
-        <p>
-          A unique name for this target.
-        </p>
-      </td>
-    </tr>
-    <tr id="platformio_project-board">
-      <td><code>board</code></td>
-      <td>
-        String; required
-        <p>
-          A string, name of the Arduino board to build this project for. You can
-find the supported boards in the
-[PlatformIO Embedded Boards Explorer](http://platformio.org/boards). This is
-mandatory.
-        </p>
-      </td>
-    </tr>
-    <tr id="platformio_project-build_flags">
-      <td><code>build_flags</code></td>
-      <td>
-        List of strings; optional
-        <p>
-          A list of strings, any provided strings will directly appear in the
-generated platformio.ini file in the build_flags option for the selected
-env:board section. Refer to the [Project Configuration File manual](
-http://docs.platformio.org/en/latest/projectconf.html) for the available
-options.
-        </p>
-      </td>
-    </tr>
-    <tr id="platformio_project-deps">
-      <td><code>deps</code></td>
-      <td>
-        <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a>; optional
-        <p>
-          A list of Bazel targets, the platformio_library targets that this one
-depends on.
-        </p>
-      </td>
-    </tr>
-    <tr id="platformio_project-environment_kwargs">
-      <td><code>environment_kwargs</code></td>
-      <td>
-        <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a>; optional
-        <p>
-          A dictionary of strings to strings, any provided keys and
-values will directly appear in the generated platformio.ini file under the
-env:board section. Refer to the [Project Configuration File manual](
-http://docs.platformio.org/en/latest/projectconf.html) for the available
-options.
-        </p>
-      </td>
-    </tr>
-    <tr id="platformio_project-framework">
-      <td><code>framework</code></td>
-      <td>
-        String; optional
-        <p>
-          A string, the name of the
-[framework](
-http://docs.platformio.org/en/latest/frameworks/index.html#frameworks) for
-this project.
-        </p>
-      </td>
-    </tr>
-    <tr id="platformio_project-platform">
-      <td><code>platform</code></td>
-      <td>
-        String; optional
-        <p>
-          A string, the name of the
-[development platform](
-http://docs.platformio.org/en/latest/platforms/index.html#platforms) for
-this project.
-        </p>
-      </td>
-    </tr>
-    <tr id="platformio_project-src">
-      <td><code>src</code></td>
-      <td>
-        <a href="https://bazel.build/docs/build-ref.html#labels">Label</a>; required
-        <p>
-          A string, the name of the C++ source file, the main file for 
-the project that contains the Arduino setup() and loop() functions. This is mandatory.
-        </p>
-      </td>
-    </tr>
-  </tbody>
-</table>
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="platformio_project-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="platformio_project-board"></a>board |  A string, name of the Arduino board to build this project for. You can find the supported boards in the [PlatformIO Embedded Boards Explorer](http://platformio.org/boards). This is mandatory.   | String | required |  |
+| <a id="platformio_project-build_flags"></a>build_flags |  A list of strings, any provided strings will directly appear in the generated platformio.ini file in the build_flags option for the selected env:board section. Refer to the [Project Configuration File manual]( http://docs.platformio.org/en/latest/projectconf.html) for the available options.   | List of strings | optional | <code>[]</code> |
+| <a id="platformio_project-deps"></a>deps |  A list of Bazel targets, the platformio_library targets that this one depends on.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
+| <a id="platformio_project-environment_kwargs"></a>environment_kwargs |  A dictionary of strings to strings, any provided keys and values will directly appear in the generated platformio.ini file under the env:board section. Refer to the [Project Configuration File manual]( http://docs.platformio.org/en/latest/projectconf.html) for the available options.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional | <code>{}</code> |
+| <a id="platformio_project-framework"></a>framework |  A string, the name of the [framework]( http://docs.platformio.org/en/latest/frameworks/index.html#frameworks) for this project.   | String | optional | <code>"arduino"</code> |
+| <a id="platformio_project-platform"></a>platform |  A string, the name of the [development platform]( http://docs.platformio.org/en/latest/platforms/index.html#platforms) for this project.   | String | optional | <code>"atmelavr"</code> |
+| <a id="platformio_project-src"></a>src |  A string, the name of the C++ source file, the main file for  the project that contains the Arduino setup() and loop() functions. This is mandatory.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
 
 

--- a/platformio/platformio.bzl
+++ b/platformio/platformio.bzl
@@ -15,7 +15,7 @@
 
 """PlatformIO Rules.
 
-These are Bazel Skylark rules for building and uploading
+These are Bazel Starlark rules for building and uploading
 [Arduino](https://www.arduino.cc/) programs using the
 [PlatformIO](http://platformio.org/) build system.
 """
@@ -69,7 +69,7 @@ def _platformio_library_impl(ctx):
   by PlatformIO.
 
   Args:
-    ctx: The Skylark context.
+    ctx: The Starlark context.
   """
   name = ctx.label.name
 
@@ -135,7 +135,7 @@ def _emit_ini_file_action(ctx):
   """Emits a Bazel action that generates the PlatformIO configuration file.
 
   Args:
-    ctx: The Skylark context.
+    ctx: The Starlark context.
   """
   environment_kwargs = []
   if ctx.attr.environment_kwargs:
@@ -168,7 +168,7 @@ def _emit_main_file_action(ctx):
   """Emits a Bazel action that outputs the project main C++ file.
 
   Args:
-    ctx: The Skylark context.
+    ctx: The Starlark context.
   """
   ctx.actions.run_shell(
       inputs=[ctx.file.src],
@@ -182,7 +182,7 @@ def _emit_build_action(ctx, project_dir):
   """Emits a Bazel action that unzips the libraries and builds the project.
 
   Args:
-    ctx: The Skylark context.
+    ctx: The Starlark context.
     project_dir: A string, the main directory of the PlatformIO project.
       This is where the zip files will be extracted.
   """
@@ -230,7 +230,7 @@ def _emit_executable_action(ctx):
   Arduino device.
 
   Args:
-    ctx: The Skylark context.
+    ctx: The Starlark context.
   """
   # TODO(mum4k): Make this script smarter, when executed via Bazel, the current
   # directory is project_name.runfiles/__main__ so we need to go two dirs up.
@@ -252,7 +252,7 @@ def _platformio_project_impl(ctx):
   is the compiled version of the Arduino firmware for the specified board.
 
   Args:
-    ctx: The Skylark context.
+    ctx: The Starlark context.
   """
   _emit_ini_file_action(ctx)
   _emit_main_file_action(ctx)


### PR DESCRIPTION
Update all dependencies to latest versions

Use Starlark as the new name for Skylark

Regenerated documentation

bazel test ... passes