### PR TITLE
Cleanup warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 
 # Ignore vim swap files.
 *.swp
+
+# Ignore VSCode files
+.vscode

--- a/platformio/platformio.bzl
+++ b/platformio/platformio.bzl
@@ -121,7 +121,8 @@ def _platformio_library_impl(ctx):
   )
 
   # Collect the zip files produced by all transitive dependancies.
-  transitive_zip_files=[dep[DefaultInfo].default_runfiles for dep in ctx.attr.deps]
+  transitive_zip_files=[
+    dep[DefaultInfo].default_runfiles for dep in ctx.attr.deps]
   runfiles=ctx.runfiles(files=[ctx.outputs.zip])
   runfiles=runfiles.merge_all(transitive_zip_files)
   return DefaultInfo(
@@ -184,7 +185,10 @@ def _emit_build_action(ctx, project_dir):
     project_dir: A string, the main directory of the PlatformIO project.
       This is where the zip files will be extracted.
   """
-  transitive_zip_files=depset(transitive=[dep[DefaultInfo].default_runfiles.files for dep in ctx.attr.deps])
+  transitive_zip_files=depset(
+    transitive=[
+      dep[DefaultInfo].default_runfiles.files for dep in ctx.attr.deps
+  ])
 
   commands = []
   for zip_file in transitive_zip_files.to_list():


### PR DESCRIPTION
Replace deprecated usage of structs with the recommended provider infrastructure

Removed unnecessary depth in depset management