### PR TITLE
Clean up WORKSPACE files for users

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,23 @@ See [Releases](https://github.com/mum4k/platformio_rules/releases) for the most 
 
 ```
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
-
 git_repository(
     name = "platformio_rules",
     remote = "http://github.com/mum4k/platformio_rules.git",
-    tag = "v0.0.9",
+    tag = "v0.0.13",
 )
+
+load("@platformio_rules//bazel:deps.bzl", "platformio_rules_dependencies")
+platformio_rules_dependencies()
+
+load("@platformio_rules//bazel:transitive.bzl", "platformio_rules_transitive_dependencies")
+platformio_rules_transitive_dependencies()
+
+load("@platformio_rules//bazel:pip_parse.bzl", "platformio_rules_pip_parse_dependencies")
+platformio_rules_pip_parse_dependencies()
+
+load("@platformio_rules//bazel:pip_install.bzl", "platformio_rules_pip_install_dependencies")
+platformio_rules_pip_install_dependencies()
 ```
 
 ### Load the rule definitions in the BUILD file

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -27,8 +27,14 @@ platformio_rules_dependencies()
 load("//bazel:transitive.bzl", "platformio_rules_transitive_dependencies")
 platformio_rules_transitive_dependencies()
 
-load("//bazel:pip_parse.bzl", "platformio_rules_pip_parse_dependencies")
-platformio_rules_pip_parse_dependencies()
+load("@python3_10_8//:defs.bzl", "interpreter")
+load("@rules_python//python:pip.bzl", "pip_parse")
+
+pip_parse(
+    name = "py_deps",
+    python_interpreter_target = interpreter,
+    requirements_lock = "//:requirements_lock.txt",
+)
 
 load("//bazel:pip_install.bzl", "platformio_rules_pip_install_dependencies")
 platformio_rules_pip_install_dependencies()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -21,37 +21,14 @@ http_archive(
     sha256 = "4756ab3ec46d94d99e5ed685d2d24aece484015e45af303eb3a11cab3cdc2e71",
 )
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("//:bazel/deps.bzl", "platformio_rules_dependencies")
+platformio_rules_dependencies()
 
-git_repository(
-    name = "io_bazel_stardoc",
-    remote = "https://github.com/bazelbuild/stardoc.git",
-    tag = "0.5.3",
-)
+load("//:bazel/transitive.bzl", "platformio_rules_transitive_dependencies")
+platformio_rules_transitive_dependencies()
 
-load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
-stardoc_repositories()
+load("//:bazel/pip_parse.bzl", "pip_parse_dependencies")
+pip_parse_dependencies()
 
-# Python library manager (pip)
-http_archive(
-    name = "rules_python",
-    sha256 = "81cbfc16dd1c022c4761267fa8b2feb881aaea9c3e1143f2e64630a1ad18c347",
-    strip_prefix = "rules_python-0.16.1",
-    url = "https://github.com/bazelbuild/rules_python/archive/0.16.1.zip",
-)
-load("@rules_python//python:repositories.bzl", "python_register_toolchains")
-python_register_toolchains(
-    name = "python3_10_8",
-    # Available versions are listed in @rules_python//python:versions.bzl.
-    # We recommend using the same version your team is already standardized on.
-    python_version = "3.10.8",
-)
-load("@python3_10_8//:defs.bzl", "interpreter")
-load("@rules_python//python:pip.bzl", "pip_parse")
-pip_parse(
-    name = "py_deps",
-    python_interpreter_target = interpreter,
-    requirements_lock = "//:requirements_lock.txt",
-)
-load("@py_deps//:requirements.bzl", "install_deps")
-install_deps()
+load("//:bazel/pip_install.bzl", "pip_install_dependencies")
+pip_install_dependencies()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -21,14 +21,14 @@ http_archive(
     sha256 = "4756ab3ec46d94d99e5ed685d2d24aece484015e45af303eb3a11cab3cdc2e71",
 )
 
-load("//:bazel/deps.bzl", "platformio_rules_dependencies")
+load("//bazel:deps.bzl", "platformio_rules_dependencies")
 platformio_rules_dependencies()
 
-load("//:bazel/transitive.bzl", "platformio_rules_transitive_dependencies")
+load("//bazel:transitive.bzl", "platformio_rules_transitive_dependencies")
 platformio_rules_transitive_dependencies()
 
-load("//:bazel/pip_parse.bzl", "pip_parse_dependencies")
-pip_parse_dependencies()
+load("//bazel:pip_parse.bzl", "platformio_rules_pip_parse_dependencies")
+platformio_rules_pip_parse_dependencies()
 
-load("//:bazel/pip_install.bzl", "pip_install_dependencies")
-pip_install_dependencies()
+load("//bazel:pip_install.bzl", "platformio_rules_pip_install_dependencies")
+platformio_rules_pip_install_dependencies()

--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -1,12 +1,19 @@
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+# Load the main dependencies from platformio_rules
+#
+# This cannot load all the dependencies, as some load()s are needed from these,
+# which cannot be done in a function, but this is the first step of the process
 def platformio_rules_dependencies():
+    # Import Stardoc, to write the documentation to our Starlark rules
     git_repository(
         name = "io_bazel_stardoc",
         remote = "https://github.com/bazelbuild/stardoc.git",
         tag = "0.5.3",
     )
+    # Import python, this is the first step to get pip_parse() dependencies to
+    # be corrently imported
     http_archive(
         name = "rules_python",
         sha256 = "81cbfc16dd1c022c4761267fa8b2feb881aaea9c3e1143f2e64630a1ad18c347",

--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -1,0 +1,15 @@
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def platformio_rules_dependencies():
+    git_repository(
+        name = "io_bazel_stardoc",
+        remote = "https://github.com/bazelbuild/stardoc.git",
+        tag = "0.5.3",
+    )
+    http_archive(
+        name = "rules_python",
+        sha256 = "81cbfc16dd1c022c4761267fa8b2feb881aaea9c3e1143f2e64630a1ad18c347",
+        strip_prefix = "rules_python-0.16.1",
+        url = "https://github.com/bazelbuild/rules_python/archive/0.16.1.zip",
+    )

--- a/bazel/pip_install.bzl
+++ b/bazel/pip_install.bzl
@@ -1,4 +1,4 @@
 load("@py_deps//:requirements.bzl", "install_deps")
 
-def pip_install_dependencies():
+def platformio_rules_pip_install_dependencies():
     install_deps()

--- a/bazel/pip_install.bzl
+++ b/bazel/pip_install.bzl
@@ -1,4 +1,6 @@
 load("@py_deps//:requirements.bzl", "install_deps")
 
+# Finally, now that pip_parse() has been executed, install the pip dependencies
 def platformio_rules_pip_install_dependencies():
+    # Install all pip dependencies
     install_deps()

--- a/bazel/pip_install.bzl
+++ b/bazel/pip_install.bzl
@@ -1,4 +1,4 @@
 load("@py_deps//:requirements.bzl", "install_deps")
 
-def platformio_rules_dependencies():
+def pip_install_dependencies():
     install_deps()

--- a/bazel/pip_parse.bzl
+++ b/bazel/pip_parse.bzl
@@ -1,7 +1,10 @@
 load("@python3_10_8//:defs.bzl", "interpreter")
 load("@rules_python//python:pip.bzl", "pip_parse")
 
+# Now that Python has been registered, load the pip packages that are required
+# for template rendering
 def platformio_rules_pip_parse_dependencies():
+    # Load the pip packages needed
     pip_parse(
         name = "py_deps",
         python_interpreter_target = interpreter,

--- a/bazel/pip_parse.bzl
+++ b/bazel/pip_parse.bzl
@@ -5,5 +5,5 @@ def platformio_rules_pip_parse_dependencies():
     pip_parse(
         name = "py_deps",
         python_interpreter_target = interpreter,
-        requirements_lock = "//:requirements_lock.txt",
+        requirements_lock = "@platformio_rules//:requirements_lock.txt",
     )

--- a/bazel/pip_parse.bzl
+++ b/bazel/pip_parse.bzl
@@ -1,7 +1,7 @@
 load("@python3_10_8//:defs.bzl", "interpreter")
 load("@rules_python//python:pip.bzl", "pip_parse")
 
-def pip_parse_dependencies():
+def platformio_rules_pip_parse_dependencies():
     pip_parse(
         name = "py_deps",
         python_interpreter_target = interpreter,

--- a/bazel/pip_parse.bzl
+++ b/bazel/pip_parse.bzl
@@ -1,0 +1,9 @@
+load("@python3_10_8//:defs.bzl", "interpreter")
+load("@rules_python//python:pip.bzl", "pip_parse")
+
+def pip_parse_dependencies():
+    pip_parse(
+        name = "py_deps",
+        python_interpreter_target = interpreter,
+        requirements_lock = "//:requirements_lock.txt",
+    )

--- a/bazel/transitive.bzl
+++ b/bazel/transitive.bzl
@@ -1,0 +1,11 @@
+load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
+load("@rules_python//python:repositories.bzl", "python_register_toolchains")
+
+def platformio_rules_transitive_dependencies():
+    stardoc_repositories()
+    python_register_toolchains(
+        name = "python3_10_8",
+        # Available versions are listed in @rules_python//python:versions.bzl.
+        # We recommend using the same version your team is already standardized on.
+        python_version = "3.10.8",
+    )

--- a/bazel/transitive.bzl
+++ b/bazel/transitive.bzl
@@ -1,8 +1,16 @@
 load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
 load("@rules_python//python:repositories.bzl", "python_register_toolchains")
 
+# Load the first level of dependencies that are based on the ones imported in
+# platformio_rules_dependencies(), as these imports depend on load() commands
+# that come from those imports
 def platformio_rules_transitive_dependencies():
+    # Import all the dependencies for Stardoc, so we can write documentation for
+    # our Starlark rules
     stardoc_repositories()
+
+    # Select the Python toolchain that will be used for template rendering. This
+    # is required for pip_parse() to be executed
     python_register_toolchains(
         name = "python3_10_8",
         # Available versions are listed in @rules_python//python:versions.bzl.

--- a/platformio/deps.bzl
+++ b/platformio/deps.bzl
@@ -1,0 +1,4 @@
+load("@py_deps//:requirements.bzl", "install_deps")
+
+def platformio_rules_dependencies():
+    install_deps()


### PR DESCRIPTION
Currently, if you have a repository using this one, the WORKSPACE for that repository is full of sections that are dependent on the internal implementation of platformio_rules. This PR creates Starlark libraries to define those WORKSPACE files easily and cleanly

bazel build ... && bazel test ... passes