### PR TITLE
Add lib_deps and lib_ldf_mode to platformio rules

### DIFF
--- a/docs/platformio_doc.md
+++ b/docs/platformio_doc.md
@@ -12,7 +12,7 @@ These are Bazel Starlark rules for building and uploading
 ## platformio_library
 
 <pre>
-platformio_library(<a href="#platformio_library-name">name</a>, <a href="#platformio_library-add_hdrs">add_hdrs</a>, <a href="#platformio_library-add_srcs">add_srcs</a>, <a href="#platformio_library-deps">deps</a>, <a href="#platformio_library-hdr">hdr</a>, <a href="#platformio_library-src">src</a>)
+platformio_library(<a href="#platformio_library-name">name</a>, <a href="#platformio_library-add_hdrs">add_hdrs</a>, <a href="#platformio_library-add_srcs">add_srcs</a>, <a href="#platformio_library-deps">deps</a>, <a href="#platformio_library-hdr">hdr</a>, <a href="#platformio_library-lib_deps">lib_deps</a>, <a href="#platformio_library-src">src</a>)
 </pre>
 
 
@@ -69,6 +69,7 @@ expected by PlatformIO.
 | <a id="platformio_library-add_srcs"></a>add_srcs |  A list of labels, additional source files to include in the resulting zip file.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
 | <a id="platformio_library-deps"></a>deps |  A list of Bazel targets, other platformio_library targets that this one depends on.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
 | <a id="platformio_library-hdr"></a>hdr |  A string, the name of the C++ header file. This is mandatory.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="platformio_library-lib_deps"></a>lib_deps |  A list of external (PlatformIO) libraries that this library depends on. These libraries will be added to any platformio_project() rules that directly or indirectly link this library.   | List of strings | optional | <code>[]</code> |
 | <a id="platformio_library-src"></a>src |  A string, the name of the C++ source file. This is optional.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
 
 
@@ -77,8 +78,8 @@ expected by PlatformIO.
 ## platformio_project
 
 <pre>
-platformio_project(<a href="#platformio_project-name">name</a>, <a href="#platformio_project-board">board</a>, <a href="#platformio_project-build_flags">build_flags</a>, <a href="#platformio_project-deps">deps</a>, <a href="#platformio_project-environment_kwargs">environment_kwargs</a>, <a href="#platformio_project-framework">framework</a>, <a href="#platformio_project-platform">platform</a>, <a href="#platformio_project-port">port</a>,
-                   <a href="#platformio_project-programmer">programmer</a>, <a href="#platformio_project-src">src</a>, <a href="#platformio_project-upload_fs">upload_fs</a>)
+platformio_project(<a href="#platformio_project-name">name</a>, <a href="#platformio_project-board">board</a>, <a href="#platformio_project-build_flags">build_flags</a>, <a href="#platformio_project-deps">deps</a>, <a href="#platformio_project-environment_kwargs">environment_kwargs</a>, <a href="#platformio_project-framework">framework</a>, <a href="#platformio_project-lib_deps">lib_deps</a>,
+                   <a href="#platformio_project-lib_ldf_mode">lib_ldf_mode</a>, <a href="#platformio_project-platform">platform</a>, <a href="#platformio_project-port">port</a>, <a href="#platformio_project-programmer">programmer</a>, <a href="#platformio_project-src">src</a>, <a href="#platformio_project-upload_fs">upload_fs</a>)
 </pre>
 
 
@@ -114,10 +115,31 @@ uploading.
 | <a id="platformio_project-deps"></a>deps |  A list of Bazel targets, the platformio_library targets that this one depends on.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
 | <a id="platformio_project-environment_kwargs"></a>environment_kwargs |  A dictionary of strings to strings, any provided keys and values will directly appear in the generated platformio.ini file under the env:board section. Refer to the [Project Configuration File manual]( http://docs.platformio.org/en/latest/projectconf.html) for the available options.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional | <code>{}</code> |
 | <a id="platformio_project-framework"></a>framework |  A string, the name of the [framework]( http://docs.platformio.org/en/latest/frameworks/index.html#frameworks) for this project.   | String | optional | <code>"arduino"</code> |
+| <a id="platformio_project-lib_deps"></a>lib_deps |  A list of external (PlatformIO) libraries that this project depends on.   | List of strings | optional | <code>[]</code> |
+| <a id="platformio_project-lib_ldf_mode"></a>lib_ldf_mode |  Library dependency finder for PlatformIO (https://docs.platformio.org/en/stable/librarymanager/ldf.html).   | String | optional | <code>"deep+"</code> |
 | <a id="platformio_project-platform"></a>platform |  A string, the name of the [development platform]( http://docs.platformio.org/en/latest/platforms/index.html#platforms) for this project.   | String | optional | <code>"atmelavr"</code> |
 | <a id="platformio_project-port"></a>port |  Port where your microcontroller is connected. This field is mandatory if you are using arduino_as_isp as your programmer.   | String | optional | <code>""</code> |
 | <a id="platformio_project-programmer"></a>programmer |  Type of programmer to use: - direct: Use the USB connection in the microcontroller deveopment board to program it - arduino_as_isp: Use an arduino programmed with the Arduino as ISP code to in-circuit program another microcontroller (see https://docs.arduino.cc/built-in-examples/arduino-isp/ArduinoISP for details). - usbtinyisp: Use an USBTinyISP programmer, like https://www.amazon.com/gp/product/B09DG384MK   | String | optional | <code>"direct"</code> |
 | <a id="platformio_project-src"></a>src |  A string, the name of the C++ source file, the main file for  the project that contains the Arduino setup() and loop() functions. This is mandatory.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
 | <a id="platformio_project-upload_fs"></a>upload_fs |  Filegroup containing files to upload to the device's FS memory.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
+
+
+<a id="PlatformIOLibraryInfo"></a>
+
+## PlatformIOLibraryInfo
+
+<pre>
+PlatformIOLibraryInfo(<a href="#PlatformIOLibraryInfo-default_runfiles">default_runfiles</a>, <a href="#PlatformIOLibraryInfo-transitive_libdeps">transitive_libdeps</a>)
+</pre>
+
+Information needed to define a PlatformIO library.
+
+**FIELDS**
+
+
+| Name  | Description |
+| :------------- | :------------- |
+| <a id="PlatformIOLibraryInfo-default_runfiles"></a>default_runfiles |  Files needed to execute anything depending on this library.    |
+| <a id="PlatformIOLibraryInfo-transitive_libdeps"></a>transitive_libdeps |  External platformIO libraries needed by this library.    |
 
 

--- a/platformio/platformio.bzl
+++ b/platformio/platformio.bzl
@@ -193,6 +193,7 @@ def _emit_ini_file_action(ctx, output_files):
     build_flags=build_flags,
     programmer=ctx.attr.programmer,
     port=ctx.attr.port,
+    lib_deps=ctx.attr.lib_deps,
   ).to_json()
   ctx.actions.run(
     outputs=[output_files.platformio_ini],
@@ -550,6 +551,14 @@ A list of Bazel targets, the platformio_library targets that this one
 depends on.
 """,
       ),
+      "lib_deps": attr.string_list(
+        allow_empty = True,
+        mandatory = False,
+        default = [],
+        doc = """
+A list of external (PlatformIO) libraries that this project depends on.
+""",
+      ),
       "upload_fs": attr.label(
         default = None,
         mandatory = False,
@@ -558,7 +567,7 @@ depends on.
         doc = """
 Filegroup containing files to upload to the device's FS memory.
 """
-      )
+      ),
     },
     doc = """
 Defines a project that will be built and uploaded using PlatformIO.

--- a/platformio/platformio.bzl
+++ b/platformio/platformio.bzl
@@ -193,6 +193,7 @@ def _emit_ini_file_action(ctx, output_files):
     build_flags=build_flags,
     programmer=ctx.attr.programmer,
     port=ctx.attr.port,
+    lib_ldf_mode=ctx.attr.lib_ldf_mode,
     lib_deps=ctx.attr.lib_deps,
   ).to_json()
   ctx.actions.run(
@@ -549,6 +550,14 @@ https://www.amazon.com/gp/product/B09DG384MK
         doc = """
 A list of Bazel targets, the platformio_library targets that this one
 depends on.
+""",
+      ),
+      "lib_ldf_mode": attr.string(
+        default = "deep+",
+        mandatory = False,
+        doc = """
+Library dependency finder for PlatformIO
+(https://docs.platformio.org/en/stable/librarymanager/ldf.html)
 """,
       ),
       "lib_deps": attr.string_list(

--- a/platformio/platformio.ini.tmpl
+++ b/platformio/platformio.ini.tmpl
@@ -22,6 +22,10 @@ build_flags =
   {{ flag }}
 {%- endfor %}
 lib_ldf_mode = deep+
+lib_deps =
+{%- for lib in lib_deps %}
+  {{ lib }}
+{%- endfor %}
 platform = {{ platform }}
 board = {{ board }}
 framework = 

--- a/platformio/platformio.ini.tmpl
+++ b/platformio/platformio.ini.tmpl
@@ -21,7 +21,7 @@ build_flags =
 {%- for flag in build_flags %}
   {{ flag }}
 {%- endfor %}
-lib_ldf_mode = deep+
+lib_ldf_mode = {{ lib_ldf_mode }}
 lib_deps =
 {%- for lib in lib_deps %}
   {{ lib }}

--- a/tests/rgb_blink/BUILD
+++ b/tests/rgb_blink/BUILD
@@ -1,0 +1,17 @@
+load("//platformio:platformio.bzl", "platformio_library", "platformio_project")
+
+platformio_library(
+    name = "rgb_led",
+    src = "rgb_led.cc",
+    hdr = "rgb_led.h",
+    lib_deps = ["adafruit/Adafruit NeoPixel#1.11.0"],
+)
+
+platformio_project(
+    name = "rgb_blink",
+    src = "rgb_blink.cc",
+    board = "esp32-s3-devkitc-1",
+    framework = "arduino",
+    platform = "espressif32",
+    deps = [":rgb_led"],
+)

--- a/tests/rgb_blink/rgb_blink.cc
+++ b/tests/rgb_blink/rgb_blink.cc
@@ -1,0 +1,26 @@
+// Blink an LED. The "hello world" of electronics.
+//
+// By default this will blink an LED connected to pin 13 (standard Arduino)
+// with a 1/2 Hz frequency and a 50% duty cycle (1 second on, 1 second off).
+//
+// You can change the behaviour with the following macros at compile time:
+// - TARGET_PIN: The number of the pin where the LED is connected to
+// - TIME_HIGH_MS: The number of milliseconds the LED will be on per cycle
+// - TIME_LOW_MS: The number of milliseconds the LED will be off per cycle
+
+#include <Arduino.h>
+#include <rgb_led.h>
+
+// This is the pin used in the first version of the ESP32-S3 devkit
+RGBLed led(48);
+
+void setup() {}
+
+void loop () {
+    led.SetColor(255,0,0);
+    delay(500);
+    led.SetColor(0,255,0);
+    delay(500);
+    led.SetColor(0,0,255);
+    delay(500);
+}

--- a/tests/rgb_blink/rgb_led.cc
+++ b/tests/rgb_blink/rgb_led.cc
@@ -1,0 +1,8 @@
+#include <rgb_led.h>
+
+RGBLed::RGBLed(int ledPin) : led_(1, ledPin, NEO_GRB + NEO_KHZ800) {}
+
+void RGBLed::SetColor(uint16_t red, uint16_t green, uint16_t blue) {
+    led_.setPixelColor(0, red, green, blue);
+    led_.show();
+}

--- a/tests/rgb_blink/rgb_led.h
+++ b/tests/rgb_blink/rgb_led.h
@@ -1,0 +1,17 @@
+#ifndef TEST_RGB_BLINK_RGB_LED_H
+#define TEST_RGB_BLINK_RGB_LED_H
+
+#include <stdint.h>
+#include <Adafruit_NeoPixel.h>
+
+class RGBLed {
+public:
+    RGBLed(int ledPin);
+
+    void SetColor(uint16_t red, uint16_t green, uint16_t blue);
+
+protected:
+    Adafruit_NeoPixel led_;
+};
+
+#endif // TEST_RGB_BLINK_RGB_LED_H


### PR DESCRIPTION
Add lib_deps support to both platformio_library() and platformio_project(), and lib_ldf_mode to platformio_project()

This allows to set the external libraries that building a project requires, so platformio can download them at build time and not depend on the installed libraries on the user's machine

Adds a new test binary (test/rgb_blink) to test this functionality

All code builds and tests pass
joso@pop-os:~/git/platformio_rules$ bazel clean --expunge
INFO: Starting clean (this may take a while). Consider using --async if the clean takes more than several minutes.

joso@pop-os:~/git/platformio_rules$ bazel build ...
Starting local Bazel server and connecting to it...
DEBUG: Rule 'io_bazel_stardoc' indicated that a canonical reproducible form can be obtained by modifying arguments commit = "50cb91505b14b1dd07e32eb6145c5767b7a629c7" and dropping ["tag"]
DEBUG: Repository io_bazel_stardoc instantiated at:
  /home/joso/git/platformio_rules/WORKSPACE:25:30: in <toplevel>
  /home/joso/git/platformio_rules/bazel/deps.bzl:10:19: in platformio_rules_dependencies
Repository rule git_repository defined at:
  /home/joso/.cache/bazel/_bazel_joso/e97f26a8b58df374fb064ff4a095894c/external/bazel_tools/tools/build_defs/repo/git.bzl:181:33: in <toplevel>
INFO: Analyzed 28 targets (76 packages loaded, 3905 targets configured).
INFO: Found 28 targets...
INFO: From Action tests/arduino/lib/Arduino_interface/Arduino_interface.h:
/home/joso/.cache/bazel/_bazel_joso/e97f26a8b58df374fb064ff4a095894c/execroot/__main__
INFO: From Action tests/binary_counter/led_display/lib/Led_display/Led_display.h:
/home/joso/.cache/bazel/_bazel_joso/e97f26a8b58df374fb064ff4a095894c/execroot/__main__
INFO: From Action tests/arduino/lib/Arduino_impl/Arduino_impl.h:
/home/joso/.cache/bazel/_bazel_joso/e97f26a8b58df374fb064ff4a095894c/execroot/__main__
INFO: From Action tests/binary_counter/convert/lib/Convert/Convert.h:
/home/joso/.cache/bazel/_bazel_joso/e97f26a8b58df374fb064ff4a095894c/execroot/__main__
INFO: From Action tests/binary_counter/button_presses/lib/Button_presses/Button_presses.h:
/home/joso/.cache/bazel/_bazel_joso/e97f26a8b58df374fb064ff4a095894c/execroot/__main__
INFO: From Action tests/rgb_blink/lib/rgb_led/rgb_led.h:
/home/joso/.cache/bazel/_bazel_joso/e97f26a8b58df374fb064ff4a095894c/execroot/__main__
INFO: From Action tests/rgb_blink/rgb_blink_workdir/.pio/build/esp32-s3-devkitc-1/firmware.elf:
Library Manager: Installing adafruit/Adafruit NeoPixel#1.11.0
Unpacking
Library Manager: Adafruit NeoPixel@1.11.0 has been installed!
INFO: Elapsed time: 16.891s, Critical Path: 7.78s
INFO: 128 processes: 62 internal, 66 local.
INFO: Build completed successfully, 128 total actions

joso@pop-os:~/git/platformio_rules$ bazel test ...
INFO: Analyzed 28 targets (1 packages loaded, 504 targets configured).
INFO: Found 24 targets and 4 test targets...
INFO: Elapsed time: 1.453s, Critical Path: 1.21s
INFO: 5 processes: 5 local.
INFO: Build completed successfully, 5 total actions
//:requirements_test                                                     PASSED in 1.1s
//tests/binary_counter/button_presses:button_presses_test                PASSED in 0.0s
//tests/binary_counter/convert:convert_test                              PASSED in 0.0s
//tests/binary_counter/led_display:led_display_test                      PASSED in 0.0s

Executed 4 out of 4 tests: 4 tests pass.
There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones these are.
